### PR TITLE
esn-frontend-common-libs#51 Implemented theming using CSS Variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "clipboard": "1.5.16",
     "dompurify": "1.0.9",
     "email-addresses": "3.0.0",
+    "hex-to-hsl": "1.0.2",
     "iframe-resizer": "3.5.5",
     "jquery": "2.1.1",
     "jquery.focus": "0.1.4",

--- a/src/frontend/css/colors.less
+++ b/src/frontend/css/colors.less
@@ -4,15 +4,35 @@
 // @m-white: #FFFFFF
 // @m-black: #000000
 
+@plugin './plugins/color';
+
+:root {
+  --primary-color-h: hue(@m-blue);
+  --primary-color-s: saturation(@m-blue);
+  --primary-color-l: lightness(@m-blue);
+  --accent-color-h: hue(@m-amber);
+  --accent-color-s: saturation(@m-amber);
+  --accent-color-l: lightness(@m-amber);
+  --body-bg-color-h: hue(darken(@m-white, 3%));
+  --body-bg-color-s: saturation(darken(@m-white, 3%));
+  --body-bg-color-l: lightness(darken(@m-white, 3%));
+  --text-primary-color-h: hue(@m-white);
+  --text-primary-color-s: saturation(@m-white);
+  --text-primary-color-l: lightness(@m-white);
+  --text-color-h: hue(lighten(@m-black, 20%));
+  --text-color-s: saturation(lighten(@m-black, 20%));
+  --text-color-l: lightness(lighten(@m-black, 20%));
+}
+
 // main colors
-@primaryColor: @m-blue;
-@accentColor: @m-amber;
-@bodyBgColor: darken(@m-white, 3%);
+@primaryColor: hsl(var(--primary-color-h), var(--primary-color-s), var(--primary-color-l));
+@accentColor: hsl(var(--accent-color-h), var(--accent-color-s), var(--accent-color-l));
+@bodyBgColor: hsl(var(--body-bg-color-h), var(--body-bg-color-s), var(--body-bg-color-l));
 
 // text colors
-@textPrimaryColor: @m-white;
+@textPrimaryColor: hsl(var(--text-primary-color-h), var(--text-primary-color-s), var(--text-primary-color-l));
 @textAccentColor: @m-white;
-@textColor: lighten(@m-black, 20%);
+@textColor: hsl(var(--text-color-h), var(--text-color-s), var(--text-color-l));
 @secondaryTextColor: lighten(@textColor, 20%);
 
 // header colors

--- a/src/frontend/css/plugins/color.js
+++ b/src/frontend/css/plugins/color.js
@@ -1,0 +1,69 @@
+const colorFunctions = require('less/lib/less/functions/color').default;
+
+const SUPPORTED_COLOR_FUNCTIONS = {
+  LIGHTEN: 'lighten',
+  DARKEN: 'darken',
+  FADE: 'fade'
+};
+
+// TODO (esn-frontend-common-libs#51): Write tests for this plugin
+function colorFunctionInterceptor(color, amount, method, functionName) {
+  if (!Object.values(SUPPORTED_COLOR_FUNCTIONS).includes(functionName)) {
+    throw new Error(`The LESS's color function '${functionName}' is not supported with CSS Variables`);
+  }
+
+  // If the "color" argument is a known, concrete color, not a CSS Variable, we'll just use the default LESS function.
+  if (color.toHSL) return colorFunctions[functionName](color, amount, method);
+
+  // If the "color" argument is not a transformed one, we'll first transform it here.
+  if (color.args) return _firstTransform();
+
+  // Else, if the current "color" argument has already been transformed at least once, its value will be just a string.
+  // e.g. hsl(var(--primary-color-h), var(--primary-color-s), calc(var(--primary-color-l) + 20%)). Therefore we need to process it as a string.
+  return _nthTransform();
+
+  function _firstTransform() {
+    const h = color.args[0].args[0].value;
+    const s = color.args[1].args[0].value;
+    const l = color.args[2].args[0].value;
+
+    if (functionName === SUPPORTED_COLOR_FUNCTIONS.FADE) {
+      return `hsla(var(${h}), var(${s}), calc(var(${l})), ${amount.value}%)`
+    }
+
+    if (functionName === SUPPORTED_COLOR_FUNCTIONS.LIGHTEN || functionName === SUPPORTED_COLOR_FUNCTIONS.DARKEN) {
+      const sign = functionName === SUPPORTED_COLOR_FUNCTIONS.LIGHTEN ? '+' : '-';
+
+      return `hsla(var(${h}), var(${s}), calc(var(${l}) ${sign} ${amount.value}%), 100%)`;
+    }
+  }
+
+  function _nthTransform() {
+    const lastCommaIndex = color.value.lastIndexOf(',');
+
+    if (functionName === SUPPORTED_COLOR_FUNCTIONS.FADE) { 
+      return color.value.substring(0, lastCommaIndex + 2) + `${amount.value}%)`;
+    }
+
+    const secondCommaIndex = color.value.indexOf(',', color.value.indexOf(',') + 1);
+    const restOfColorString = color.value.substring(lastCommaIndex - 1);
+
+    return color.value.substring(0, secondCommaIndex) + color.value.substring(secondCommaIndex, lastCommaIndex - 1) + ` + ${amount.value}%)` + restOfColorString;
+  }
+}
+
+module.exports = {
+  install: function (less, pluginManager, functions) {
+    functions.add(SUPPORTED_COLOR_FUNCTIONS.LIGHTEN, function (color, amount, method) {
+      return colorFunctionInterceptor(color, amount, method, SUPPORTED_COLOR_FUNCTIONS.LIGHTEN);
+    });
+
+    functions.add(SUPPORTED_COLOR_FUNCTIONS.DARKEN, function (color, amount, method) {
+      return colorFunctionInterceptor(color, amount, method, SUPPORTED_COLOR_FUNCTIONS.DARKEN);
+    });
+
+    functions.add(SUPPORTED_COLOR_FUNCTIONS.FADE, function (color, amount, method) {
+      return colorFunctionInterceptor(color, amount, method, SUPPORTED_COLOR_FUNCTIONS.FADE);
+    })
+  }
+};

--- a/src/frontend/js/modules/session.js
+++ b/src/frontend/js/modules/session.js
@@ -92,29 +92,44 @@
     $scope.domain = session.domain;
   })
 
+  // TODO (esn-frontend-common-libs#51): Write tests for the new changes (https://github.com/OpenPaaS-Suite/esn-frontend-common-libs/pull/48)
   .controller('sessionInitESNController', function($scope, esnTemplate, sessionFactory) {
-
     $scope.session = {
       template: esnTemplate.templates.loading
     };
 
-    sessionFactory.fetchUser(function(error) {
-      if (error) {
+    sessionFactory.bootstrapSession()
+      .then(() => {
+        $scope.session.template = esnTemplate.templates.success;
+      })
+      .catch(error => {
         $scope.session.error = error.data;
         $scope.session.template = esnTemplate.templates.error;
-      } else {
-        $scope.session.template = esnTemplate.templates.success;
-      }
-    });
+      });
   })
 
-  .factory('sessionFactory', function($log, $q, Restangular, userAPI, domainAPI, session) {
+  .factory('sessionFactory', function($log, $q, Restangular, userAPI, domainAPI, session, themesService, applyThemeService) {
 
     function onError(error, callback) {
           if (error && error.data) {
             return callback(error.data);
           }
         }
+
+    function bootstrapSession() {
+      return new Promise((resolve, reject) => {
+        fetchUser(error => {
+          if (error) return reject(error);
+
+          themesService.getTheme(session.domain._id).then(theme => {
+            applyThemeService.applyTheme(theme);
+            resolve();
+          }).catch(error => {
+            reject(error);
+          });
+        });
+      });
+    }
 
     function fetchUser(callback) {
           userAPI.currentUser().then(function(response) {
@@ -154,7 +169,8 @@
         }
 
     return {
-      fetchUser: fetchUser
+      fetchUser,
+      bootstrapSession
     };
   });
 
@@ -163,3 +179,4 @@
 require('./template/template.module.js');
 require('./user/user.module.js');
 require('./domain.js');
+require('./themes/themes.module');

--- a/src/frontend/js/modules/session.js
+++ b/src/frontend/js/modules/session.js
@@ -124,9 +124,7 @@
           themesService.getTheme(session.domain._id).then(theme => {
             applyThemeService.applyTheme(theme);
             resolve();
-          }).catch(error => {
-            reject(error);
-          });
+          }).catch(reject);
         });
       });
     }

--- a/src/frontend/js/modules/themes/apply-theme.service.js
+++ b/src/frontend/js/modules/themes/apply-theme.service.js
@@ -4,23 +4,9 @@ angular.module('esn.themes').factory('applyThemeService', applyThemeService);
 
 // TODO (esn-frontend-common-libs#51): Write tests for this module
 function applyThemeService() {
-  const camelToKebabCase = text => text.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`);
-
-  function _convertThemeToCSS(theme) {
-    return `
-      :root {
-        ${Object.keys(theme.colors).map(color => {
-          const [h, s, l] = hexToHsl(theme.colors[color]);
-
-          return `
-            --${camelToKebabCase(color)}-h: ${h};
-            --${camelToKebabCase(color)}-s: ${s}%;
-            --${camelToKebabCase(color)}-l: ${l}%;
-          `;
-        }).join('')}
-      }
-    `;
-  }
+  return {
+    applyTheme
+  };
 
   function applyTheme(theme) {
     const THEME_STYLE_ID = 'op-current-theme';
@@ -35,7 +21,23 @@ function applyThemeService() {
     document.head.appendChild(style);
   }
 
-  return {
-    applyTheme
-  };
+  function _camelToKebabCase(text) {
+    return text.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`);
+  }
+
+  function _convertThemeToCSS(theme) {
+    return `
+      :root {
+        ${Object.keys(theme.colors).map(color => {
+          const [h, s, l] = hexToHsl(theme.colors[color]);
+
+          return `
+            --${_camelToKebabCase(color)}-h: ${h};
+            --${_camelToKebabCase(color)}-s: ${s}%;
+            --${_camelToKebabCase(color)}-l: ${l}%;
+          `;
+        }).join('')}
+      }
+    `;
+  }
 }

--- a/src/frontend/js/modules/themes/apply-theme.service.js
+++ b/src/frontend/js/modules/themes/apply-theme.service.js
@@ -1,0 +1,41 @@
+const hexToHsl = require('hex-to-hsl');
+
+angular.module('esn.themes').factory('applyThemeService', applyThemeService);
+
+// TODO (esn-frontend-common-libs#51): Write tests for this module
+function applyThemeService() {
+  const camelToKebabCase = text => text.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`);
+
+  function _convertThemeToCSS(theme) {
+    return `
+      :root {
+        ${Object.keys(theme.colors).map(color => {
+          const [h, s, l] = hexToHsl(theme.colors[color]);
+
+          return `
+            --${camelToKebabCase(color)}-h: ${h};
+            --${camelToKebabCase(color)}-s: ${s}%;
+            --${camelToKebabCase(color)}-l: ${l}%;
+          `;
+        }).join('')}
+      }
+    `;
+  }
+
+  function applyTheme(theme) {
+    const THEME_STYLE_ID = 'op-current-theme';
+    const themeNode = document.createTextNode(_convertThemeToCSS(theme));
+    let style = document.getElementById(THEME_STYLE_ID);
+
+    if (style) return style.replaceChild(themeNode, style.firstChild);
+
+    style = document.createElement('style');
+    style.appendChild(themeNode);
+    style.id = THEME_STYLE_ID;
+    document.head.appendChild(style);
+  }
+
+  return {
+    applyTheme
+  };
+}

--- a/src/frontend/js/modules/themes/themes.module.js
+++ b/src/frontend/js/modules/themes/themes.module.js
@@ -10,3 +10,4 @@
 require('../http.js');
 require('./color-contrast.service.js');
 require('./themes.service.js');
+require('./apply-theme.service.js');


### PR DESCRIPTION
A pull request for [esn-frontend-common-libs#51](https://github.com/OpenPaaS-Suite/esn-frontend-common-libs/issues/51).

Here's the demo (you can click on the GIF to redirect to the actual video hosting site):

[![Watch the demo video](https://user-images.githubusercontent.com/24670327/87898904-b84b0800-ca79-11ea-9c1f-02bf49161c0e.gif)](https://streamable.com/4xrr8m)

I'm aware that I can't write tests until [esn#17](https://github.com/OpenPaaS-Suite/esn/issues/11) is resolved, so for now there are 3 TODOs related to writing tests, and I'll create an issue for that (https://github.com/OpenPaaS-Suite/esn-frontend-common-libs/issues/71).

Additional information:
- The `hex-to-hsl` package is quite small, only **499B** minified + gzipped (https://bundlephobia.com/result?p=hex-to-hsl@1.0.2). 