### PR TITLE
OpenPaaS-Suite/esn-frontend-inbox#34: Added usage of the `esn-app-grid` web component

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "clipboard": "1.5.16",
     "dompurify": "1.0.9",
     "email-addresses": "3.0.0",
+    "esn-frontend-application-grid": "github:openpaas-suite/esn-frontend-application-grid#main",
     "hex-to-hsl": "1.0.2",
     "iframe-resizer": "3.5.5",
     "jquery": "2.1.1",

--- a/src/frontend/css/modules/header.less
+++ b/src/frontend/css/modules/header.less
@@ -62,6 +62,7 @@
   }
   .header-actions{
     padding-right: 5px;
+    color: @primaryColor;
   }
   
   &:not(.popover) {
@@ -195,6 +196,10 @@
       .row a {
         color: @subHeaderTextColor;
       }
+    }
+
+    .header-actions {
+      color: @subHeaderTextColor;
     }
   }
 }

--- a/src/frontend/js/modules/application-menu.js
+++ b/src/frontend/js/modules/application-menu.js
@@ -1,131 +1,21 @@
-(function(angular) {
+const { applyPolyfills, defineCustomElements } = require('esn-frontend-application-grid/loader');
 
-  'use strict';
+applyPolyfills().then(() => defineCustomElements());
 
-  angular.module('esn.application-menu', [
-    'op.dynamicDirective',
-    'feature-flags'
-  ])
-
-  .constant('POPOVER_APPLICATION_MENU_OPTIONS', {
-    animation: 'am-fade',
-    placement: 'bottom',
-    template: require("../../views/modules/application-menu/application-menu.pug"),
-    html: false,
-    trigger: 'manual',
-    autoClose: true,
-    prefixEvent: 'application-menu',
-    container: 'body'
-  })
-  .constant('APP_MENU_OPEN_EVENT', 'application-menu.open')
-
-  .factory('applicationMenuTemplateBuilder', function(featureFlags, _) {
-    var template =
-    '<div>' +
-    '<a href="<%- href %>" target="<%- target %>" rel="<%- rel %>">' +
-    '<img class="esn-application-menu-icon" src="<%- iconURL %>" fallback-src="/images/application.png"/>' +
-    '<span class="label" translate>' +
-    '<%- label %>' +
-    '</span>' +
-    '</a>' +
-    '</div>';
-
-    var svgTemplate =
-      '<div>' +
-      '<a href="<%- href %>" target="<%- target %>" rel="<%- rel %>">' +
-      '<div class="esn-application-menu-icon" ng-include="\'<%- iconURL %>\'"></div>' +
-      '<span class="label" translate>' +
-      '<%- label %>' +
-      '</span>' +
-      '</a>' +
-      '</div>';
-
-      return function(href, icon, label, flag, isDisplayedByDefault) {
-        var iconURL, aHref, aTarget;
-        var aRel = '';
-      var iconUrlTemplate = '/images/application-menu/<%- icon %>-icon.svg';
-      var defaultValue = angular.isDefined(isDisplayedByDefault) ? isDisplayedByDefault : true;
-      var isActive = defaultValue;
-
-      if (angular.isDefined(flag)) {
-        isActive = featureFlags.isOn(flag) === undefined ? defaultValue : featureFlags.isOn(flag);
-      }
-
-      if (!isActive) {
-        return '';
-      }
-
-      if (icon.url) {
-        iconURL = icon.url;
-      } else if (icon.name) {
-        iconURL = _.template(iconUrlTemplate)({icon: icon.name});
-      }
-
-      if (angular.isObject(href)) {
-        aHref = href.url;
-        aTarget = href.target || '';
-        aRel = href.rel || aRel;
-      } else {
-        aHref = href;
-        aTarget = '';
-      }
-
-      return iconURL && iconURL.match(/.\S+\.svg/) ?
-      _.template(svgTemplate)({ href: aHref, target: aTarget, rel: aRel, iconURL: iconURL, label: label }) :
-      _.template(template)({ href: aHref, target: aTarget, rel: aRel, iconURL: iconURL, label: label });
-    };
-  })
-
-  .directive('applicationMenuToggler', function($rootScope, $document, $popover,
-    POPOVER_APPLICATION_MENU_OPTIONS, APP_MENU_OPEN_EVENT) {
+// TODO: Write tests for this
+angular.module('esn.application-menu', [])
+  .directive('applicationMenuToggler', function($log) {
     return {
       restrict: 'E',
       scope: true,
       replace: true,
       template: require("../../views/modules/application-menu/application-menu-toggler.pug"),
-      link: function(scope, element) {
-        var backdrop = angular.element('<div id="application-menu-backdrop" class="modal-backdrop in visible-xs">'),
-        body = $document.find('body').eq(0),
-            popover = $popover(element, POPOVER_APPLICATION_MENU_OPTIONS);
+      link: function($scope) {
+        $scope.appGridItems = process.env.APP_GRID_ITEMS;
 
-            popover.$scope.$on('application-menu.show.before', function() {
-              body.append(backdrop);
-              $rootScope.$broadcast(APP_MENU_OPEN_EVENT);
-              scope.$applyAsync();
-            });
-
-            popover.$scope.$on('application-menu.hide.before', function() {
-              backdrop.remove();
-              scope.$applyAsync();
-            });
-
-            element.click(popover.toggle.bind(null, null));
-      }
-    };
-  })
-
-  .directive('forceCloseOnLinksClick', function($timeout) {
-    return {
-      restrict: 'A',
-      link: function(scope, element) {
-        $timeout(function() {
-          element.find('a').click(scope.$parent.$hide.bind(null, null));
-        }, 0, false);
-      }
-    };
-  })
-
-  .directive('forceMarginLeft', function($timeout) {
-    return {
-      restrict: 'A',
-      link: function(scope, element, attrs) {
-        $timeout(function() {
-          var offset = element.offset();
-
-          element.offset({top: offset.top, left: offset.left - attrs.forceMarginLeft});
-        }, 0, false);
+        if (!$scope.appGridItems) {
+          $log.error('The environment variable APP_GRID_ITEMS has not been defined yet, and the application grid will break.')
+        }
       }
     };
   });
-
-})(angular);

--- a/src/frontend/views/modules/application-menu/application-menu-toggler.pug
+++ b/src/frontend/views/modules/application-menu/application-menu-toggler.pug
@@ -1,2 +1,1 @@
-button.btn.btn-link.btn-icon.application-menu-toggler
-  i.mdi.mdi-apps
+esn-app-grid(serialized-applications='{{ appGridItems }}')

--- a/src/frontend/views/modules/application-menu/application-menu.pug
+++ b/src/frontend/views/modules/application-menu/application-menu.pug
@@ -1,1 +1,0 @@
-.popover.application-menu(dynamic-directive='esn-application-menu', force-close-on-links-click, force-margin-left="10")


### PR DESCRIPTION
Partially resolves OpenPaaS-Suite/esn-frontend-inbox#34. Please also refer to this PR for the actual code of the web component: https://github.com/OpenPaaS-Suite/esn-frontend-application-grid/pull/1

Note that we should also delete the code in our SPAs that use `applicationMenuTemplateBuilder` since it is not needed anymore with the introduction of the WC.

- Here's the desktop version of it:

![Demo-Application-Grid-Static](https://user-images.githubusercontent.com/24670327/88279123-bef1ad80-cd0d-11ea-8c25-4f49dc3ffd58.gif)

- Here's the mobile version of it:

![Demo-Application-Grid-Static-Mob](https://user-images.githubusercontent.com/24670327/88279134-c44ef800-cd0d-11ea-890a-3800da500bfe.gif)

TODOs:

- [ ] Test this on Safari & Edge (<19)