### PR TITLE
#84: Added missing dependency 'materialAdmin' to 'esn.from.helper' to make esn-form-group display correctly

### DIFF
--- a/src/frontend/js/modules/form-helper/form-helper.module.js
+++ b/src/frontend/js/modules/form-helper/form-helper.module.js
@@ -1,8 +1,6 @@
-(function(angular) {
-  'use strict';
+'use strict';
 
-  angular.module('esn.form.helper', ['ngMessages', 'esn.core']);
-})(angular);
+angular.module('esn.form.helper', ['ngMessages', 'esn.core', 'materialAdmin']);
 
 require('../core.js');
 require('../i18n/i18n.module.js');


### PR DESCRIPTION
Resolves #84.

- Screenshot (in `esn-frontend-account`):

![ESNFormGroup_Demo_1](https://user-images.githubusercontent.com/24670327/89881645-f8705700-dbef-11ea-82b3-bbb306f068fe.png)

- Screenshot (in `esn-frontend-admin`):

![EsnFormGroup_Demo_2](https://user-images.githubusercontent.com/24670327/89881846-38373e80-dbf0-11ea-8791-40fccf472625.png)