### PR TITLE
esn-frontend-calendar#42 - Add Missing Library deepStateRedirect

### DIFF
--- a/src/frontend/vendor-libs.js
+++ b/src/frontend/vendor-libs.js
@@ -59,6 +59,7 @@ require('restangular/src/restangular.js');
 require('showdown/dist/showdown.js');
 require('summernote/dist/summernote.js');
 require('ui-router-extras/release/ct-ui-router-extras.js');
+require('ui-router-extras/release/modular/ct-ui-router-extras.dsr.js');
 require('videogular/videogular.js');
 require('videogular-buffering/vg-buffering.js');
 require('videogular-controls/vg-controls.js');


### PR DESCRIPTION
Partially resolves https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/42