### PR TITLE
esn-frontend-calendar#50: Added missing ng-annotate for the search header form

### DIFF
--- a/src/frontend/js/modules/search/form/advanced/search-advanced-toggle-button.controller.js
+++ b/src/frontend/js/modules/search/form/advanced/search-advanced-toggle-button.controller.js
@@ -30,7 +30,7 @@
       var config = {
         attachTo: angular.element(document.body),
         controllerAs: 'ctrl',
-        controller: function($scope) {
+        controller: /* @ngInject */ function($scope) {
           $scope.query = self.query;
           $scope.provider = self.provider;
           $scope.$hide = hide;


### PR DESCRIPTION
Resolves https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/50 and resolves https://github.com/OpenPaaS-Suite/esn-frontend-inbox/issues/68.