### PR TITLE
esn-frontend-calendar#61: Adjusted .fc-title and .fc-time styles to make consecutive events align better

### DIFF
--- a/src/frontend/components/material-admin/less/inc/vendor-overrides/fullcalendar.less
+++ b/src/frontend/components/material-admin/less/inc/vendor-overrides/fullcalendar.less
@@ -184,7 +184,7 @@
     border: 0;
 
     .fc-title {
-		padding: 2px 8px;
+		padding: 2px 6px;
 		display: block;
     }
 
@@ -192,7 +192,6 @@
 		float: left;
 		background: rgba(0, 0, 0, 0.2);
 		padding: 2px 6px;
-		margin: 0 0 0 -1px;
     }
 }
 


### PR DESCRIPTION
Complementarily resolves https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/54. Please also refer to https://github.com/OpenPaaS-Suite/esn-frontend-calendar/pull/62.

- Before:

![esn-frontend-calendar#61-before-desktop-2](https://user-images.githubusercontent.com/24670327/91017860-f9a27a80-e618-11ea-9e4a-ab894e8a76eb.png)

- After:

![esn-frontend-calendar#61-after-desktop-1](https://user-images.githubusercontent.com/24670327/91017870-fc9d6b00-e618-11ea-9ca8-c52afe082f7d.png)
