### PR TITLE
OpenPaaS-Suite/esn-frontend-inbox#128 add support for not using history.back

### DIFF
--- a/src/frontend/js/modules/previous-page.js
+++ b/src/frontend/js/modules/previous-page.js
@@ -11,12 +11,13 @@ angular.module('esn.previous-page', [])
         // TODO: Write tests for the newly changed logic: https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/12, https://github.com/OpenPaaS-Suite/esn-frontend-inbox/issues/74
         const availableStates = $state.get();
         const backState = availableStates.find(state => state.name === attrs.esnBackButton) || availableStates.find(state => state.default);
+        const preventHistoryBack = attrs.hasOwnProperty('preventHistoryBack');
 
         if (!backState) {
           $log.warn(`There is no ${attrs.esnBackButton} state or a default state to come back to.`);
         }
 
-        element.click(() => esnPreviousPage.back(backState ? backState.name : attrs.esnBackButton));
+        element.click(() => esnPreviousPage.back(backState ? backState.name : attrs.esnBackButton, preventHistoryBack));
       }
     };
   })
@@ -29,8 +30,8 @@ angular.module('esn.previous-page', [])
       init: init
     };
 
-    function back(defaultState) {
-      if (hasPreviousPage && $window.history && $window.history.length > 0) {
+    function back(defaultState, preventHistoryBack = false) {
+      if (hasPreviousPage && $window.history && $window.history.length > 0 && !preventHistoryBack) {
         return $window.history.back();
       }
 

--- a/src/frontend/js/modules/previous-page.js
+++ b/src/frontend/js/modules/previous-page.js
@@ -8,7 +8,6 @@ angular.module('esn.previous-page', [])
     return {
       restrict: 'A',
       link: function(scope, element, attrs) {
-        // TODO: Write tests for the newly changed logic: https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/12, https://github.com/OpenPaaS-Suite/esn-frontend-inbox/issues/74
         const availableStates = $state.get();
         const backState = availableStates.find(state => state.name === attrs.esnBackButton) || availableStates.find(state => state.default);
         const preventHistoryBack = attrs.hasOwnProperty('preventHistoryBack');

--- a/src/frontend/js/modules/previous-page.spec.js
+++ b/src/frontend/js/modules/previous-page.spec.js
@@ -18,9 +18,15 @@ describe('The esn.previous-page module', function() {
 
     $provide.value('$state', $state = {
       go: sinon.spy(),
-      get: sinon.stub().returns({
-        find: function() { return []; }
-      })
+      get: sinon.stub().returns([
+        {
+          default: true,
+          name: 'expected.default.state'
+        },
+        {
+          name: 'expected.state'
+        }
+      ])
     });
     $provide.value('$window', $window);
   }));
@@ -64,6 +70,15 @@ describe('The esn.previous-page module', function() {
         expect($state.go).to.have.been.calledWith('expected.state');
       });
 
+      it('should go to the default state if the history.back is prevented', () => {
+        $window.history.length = 10;
+
+        $rootScope.$emit('$stateChangeStart', null, null, null, null, { location: true });
+        esnPreviousPage.back('expected.state', true);
+
+        expect($window.history.back).to.not.have.been.called;
+        expect($state.go).to.have.been.calledWith('expected.state');
+      });
     });
   });
 
@@ -102,6 +117,26 @@ describe('The esn.previous-page module', function() {
       element.click();
 
       expect(esnPreviousPage.back).to.have.been.calledOnce;
+    });
+
+    it('should call esnPreviousPage.back with preventHistoryBack if the attribute exists', () => {
+      esnPreviousPage.back = sinon.spy();
+      $scope = $rootScope.$new();
+
+      compileDirective('<button prevent-history-back="" esn-back-button="expected.state" />');
+      element.click();
+
+      expect(esnPreviousPage.back).to.have.been.calledWith('expected.state', true);
+    });
+
+    it('should call esnPreviousPage with the default state if the provided state does not exist', () => {
+      esnPreviousPage.back = sinon.spy();
+      $scope = $rootScope.$new();
+
+      compileDirective('<button esn-back-button="something.not.expected" />');
+      element.click();
+
+      expect(esnPreviousPage.back).to.have.been.calledWith('expected.default.state', false);
     });
   });
 


### PR DESCRIPTION
the idea is to use a directive to specify that we don't want to use `history.back`

```pug
button.btn.btn-link.btn-icon.close.button.visible-xs(prevent-history-back='', href='', esn-back-button='unifiedinbox.inbox')
```


closes https://github.com/OpenPaaS-Suite/esn-frontend-inbox/issues/128