### PR TITLE
esn-frontend-application-grid#14: Now the application grid displays properly on iOS devices

### DIFF
--- a/src/frontend/css/modules/sidebar.less
+++ b/src/frontend/css/modules/sidebar.less
@@ -7,7 +7,9 @@ body.aside-open {
 
 .aside#contextual-sidebar {
   width: 268px;
-  min-width:268px;
+  min-width: 268px;
+  overflow: unset;
+  overflow-x: visible;
 
   @media (min-width: @screen-md-min) {
     top: @header-height-md;
@@ -15,6 +17,17 @@ body.aside-open {
 
   @media (min-width: @screen-xl-min) {
     top: @header-height-xl;
+  }
+
+  .aside-wrapper {
+    position: absolute;
+
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+
+    overflow-y: auto;
   }
 
   #aside-header {

--- a/src/frontend/views/modules/sidebar/contextual-sidebar.pug
+++ b/src/frontend/views/modules/sidebar/contextual-sidebar.pug
@@ -1,20 +1,21 @@
 .aside#contextual-sidebar(tabindex="-1", role="dialog")
-  .aside-dialog
-    .aside-content
-      #aside-header(ng-if="!hideHeader")
-        div.header-inner.flex-vertical-centered.flex-space-between
-          ul.list-inline.all-centered
-            li.logo
-              a(href='', ui-sref='home')
-                img.openpaas-logo(ng-src="{{'/api/themes/' + domainId + '/favicon'}}", fallback-src='/images/logo-tiny.png', src="/images/logo-tiny.png", alt="{{ 'OpenPaas Logo' | translate }}")
-          ul.list-inline.all-centered.header-actions
-            li.hover-scale-animation
-              button.btn.btn-link.btn-icon(ui-sref='search.main')
-                i.mdi.mdi-magnify
-            li.hover-scale-animation(feature-flag="core.features.header:user-notification")
-              esn-user-notification-toggler
-            li.hover-scale-animation
-              application-menu-toggler
-            li
-              profile-menu.profile-menu
-      .aside-body(ng-bind="content", ng-class="{'hideHeader' : hideHeader}")
+  .aside-wrapper
+    .aside-dialog
+      .aside-content
+        #aside-header(ng-if="!hideHeader")
+          div.header-inner.flex-vertical-centered.flex-space-between
+            ul.list-inline.all-centered
+              li.logo
+                a(href='', ui-sref='home')
+                  img.openpaas-logo(ng-src="{{'/api/themes/' + domainId + '/favicon'}}", fallback-src='/images/logo-tiny.png', src="/images/logo-tiny.png", alt="{{ 'OpenPaas Logo' | translate }}")
+            ul.list-inline.all-centered.header-actions
+              li.hover-scale-animation
+                button.btn.btn-link.btn-icon(ui-sref='search.main')
+                  i.mdi.mdi-magnify
+              li.hover-scale-animation(feature-flag="core.features.header:user-notification")
+                esn-user-notification-toggler
+              li.hover-scale-animation
+                application-menu-toggler
+              li
+                profile-menu.profile-menu
+        .aside-body(ng-bind="content", ng-class="{'hideHeader' : hideHeader}")


### PR DESCRIPTION
Resolves https://github.com/OpenPaaS-Suite/esn-frontend-application-grid/issues/14.

![IMG_0120](https://user-images.githubusercontent.com/24670327/93294027-a84e6b00-f813-11ea-8e82-215ac3d0ca7d.PNG)

**Explanation:** It's [a Webkit bug](https://bugs.webkit.org/show_bug.cgi?id=160953). The popover is supposed to take the "body" element with `position: relative;` as the parent, but instead on iOS devices (which use Webkit-based browsers) it takes the ".aside" element with `position: fixed; overflow: auto;` as the parent. That's why it's truncated.

The code in this PR is a workaround to fix that bug (Android devices are unaffected).