### PR TITLE
https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/174 downgrade ng-tags-input package from 3.2.0 to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "mdi": "2.0.46",
     "moment": "2.15.1",
     "moment-timezone": "0.5.17",
-    "ng-tags-input": "3.2.0",
+    "ng-tags-input": "3.0.0",
     "openpaas-auth-client": "github:openpaas-suite/openpaas-auth-client#main",
     "re-tree": "0.0.2",
     "restangular": "1.6.1",

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,6 +1,10 @@
 FROM node:10-buster
 
-RUN apt-get update
-RUN apt-get install -y firefox-esr
+# Firefox for dependencies
+RUN apt update && apt install -y firefox-esr && apt remove -y firefox-esr
+
+# Fixing Firefox's version
+ENV FFV=81.0.1
+RUN cd /tmp && wget http://download-installer.cdn.mozilla.net/pub/firefox/releases/${FFV}/linux-x86_64/en-US/firefox-${FFV}.tar.bz2 && tar xvf firefox-${FFV}.tar.bz2 && ln -s /tmp/firefox/firefox /bin/firefox
 
 ENV MOZ_FORCE_DISABLE_E10S=true


### PR DESCRIPTION
From the version that greater than 3.1.0, ngTagsInput does not properly support AngularJS version 1.3.20

The breaking change at https://github.com/mbenford/ngTagsInput/blob/v3.2.0/src/auto-complete.js#L209-L215

Resolve https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/174

Tested PROD mode for calendar, inbox SPAs

![calendar](https://user-images.githubusercontent.com/7950991/95448791-10651c80-098e-11eb-9b5b-f3048a3e5184.gif)


![inbox](https://user-images.githubusercontent.com/7950991/95448867-2b379100-098e-11eb-84cf-0a5bdb1d4802.gif)
