### PR TITLE
esn-frontend-common-libs#148: Adjusted font weight of buttons

### DIFF
--- a/src/frontend/components/material-admin/less/inc/variables.less
+++ b/src/frontend/components/material-admin/less/inc/variables.less
@@ -121,7 +121,7 @@
 @border-radius-base:            2px;
 @border-radius-large:           2px; 
 @border-radius-small:           2px;
-@btn-font-weight:				400;
+@btn-font-weight:				500;
 
 /*
  * Thumbnail


### PR DESCRIPTION
Resolves https://github.com/OpenPaaS-Suite/esn-frontend-common-libs/issues/148.

- Before: The "contained" button style has a font weight of 400:

![image](https://user-images.githubusercontent.com/24670327/96666297-06c1b880-1381-11eb-8cc9-2dc1c69bbb37.png)

- After: The "contained" button style should have a font weight of 500:

![image](https://user-images.githubusercontent.com/24670327/96666364-2658e100-1381-11eb-8c04-b60f9b198d02.png)