### PR TITLE
 OpenPaaS-Suite/esn-frontend-calendar#241 Cache authentication token

### DIFF
--- a/src/frontend/js/modules/authentication.js
+++ b/src/frontend/js/modules/authentication.js
@@ -1,17 +1,46 @@
-(function(angular) {
-  'use strict';
+angular.module('esn.authentication', ['esn.http'])
+  .factory('tokenAPI', function(esnRestangular) {
 
-  angular.module('esn.authentication', ['esn.http'])
-    .factory('tokenAPI', function(esnRestangular) {
+    // https://github.com/linagora/openpaas-esn/blob/master/backend/core/auth/token.js#L3
+    // token TTL is 60 seconds server-side. We keep a lower value to get over
+    // network lags
+    const SERVER_TTL = 60 * 1000;
+    const NETWORK_LAG = 15 * 1000;
+    const CACHE_MAX_TTL = SERVER_TTL - NETWORK_LAG;
+    const cachedToken = { promise: null, timestamp: 0 };
 
-      function getNewToken() {
-        return esnRestangular.one('authenticationtoken').get();
-      }
+    return {
+      getNewToken
+    };
 
-      return {
-        getNewToken: getNewToken
-      };
-    });
-})(angular);
+    function getNewToken(resetCache = false) {
+      return resetCache ? getTokenNoCache() : getCachedToken();
+    }
+
+    function getCachedToken() {
+      const { promise, timestamp } = getCache();
+
+      return timestamp + CACHE_MAX_TTL > Date.now() ? promise : getTokenNoCache();
+    }
+
+    function getTokenNoCache() {
+      setCache(esnRestangular.one('authenticationtoken').get(), Date.now());
+
+      cachedToken.promise.catch(() => {
+        setCache(null);
+      });
+
+      return cachedToken.promise;
+    }
+
+    function setCache(promise, timestamp = 0) {
+      cachedToken.promise = promise;
+      cachedToken.timestamp = timestamp;
+    }
+
+    function getCache() {
+      return cachedToken;
+    }
+  });
 
 require('./http.js');

--- a/src/frontend/js/modules/authentication.spec.js
+++ b/src/frontend/js/modules/authentication.spec.js
@@ -1,0 +1,60 @@
+/* global chai, sinon: false */
+
+const { expect } = chai;
+const { module, inject } = angular.mock;
+
+describe('The esn.authentication tokenAPI service', function() {
+  const esnRestangular = {};
+  let tokenAPI;
+
+  beforeEach(function() {
+    module('esn.authentication');
+  });
+
+  beforeEach(module(function($provide) {
+    $provide.value('esnRestangular', esnRestangular);
+  }));
+
+  beforeEach(inject(function(_tokenAPI_) {
+    tokenAPI = _tokenAPI_;
+  }));
+
+  it('should call GET /api/authenticationtoken', function() {
+    const getSpy = sinon.fake.resolves('token1');
+
+    esnRestangular.one = sinon.fake.returns({ get: getSpy });
+
+    tokenAPI.getNewToken();
+    expect(esnRestangular.one).to.have.been.calledWith('authenticationtoken');
+    expect(getSpy).to.have.been.called;
+  });
+
+  it('should cache calls to GET /api/authenticationtoken', function() {
+    const getSpy = sinon.stub();
+
+    getSpy.resolves('token1');
+
+    esnRestangular.one = sinon.fake.returns({ get: getSpy });
+
+    return tokenAPI.getNewToken().then(() => {
+      tokenAPI.getNewToken();
+      expect(esnRestangular.one).to.have.been.calledOnceWithExactly('authenticationtoken');
+      expect(getSpy).to.have.been.calledOnce;
+    });
+  });
+
+  it('should not use cache when first argument is true', function() {
+    const getSpy = sinon.stub();
+
+    getSpy.resolves('token1');
+
+    esnRestangular.one = sinon.fake.returns({ get: getSpy });
+
+    return tokenAPI.getNewToken().then(() => {
+      tokenAPI.getNewToken(true);
+      expect(esnRestangular.one).to.have.been.calledTwice;
+      expect(esnRestangular.one).to.have.been.calledWithExactly('authenticationtoken');
+      expect(getSpy).to.have.been.calledTwice;
+    });
+  });
+});


### PR DESCRIPTION
For direct connections between a frontend & the DAV server, there is a
need to cache authentication token, otherwise any DAV request will be
preprocessed with a call to get the authentication token.