### PR TITLE
esn-frontend-calendar#218: Added block farLeft to subheader

### DIFF
--- a/src/frontend/views/modules/subheader/responsive-subheader.pug
+++ b/src/frontend/views/modules/subheader/responsive-subheader.pug
@@ -1,5 +1,6 @@
 .module-subheader.row
   .col-md-3.col-xl-2.hidden-xs
+    block farLeft
   .col-md-9.col-xl-10.col-xs-12.no-padding-xs
     .flex-space-between.module-subheader-inner
       .left-container.flex-vertical-centered


### PR DESCRIPTION
Partially resolves https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/218. Please also refer to https://github.com/OpenPaaS-Suite/esn-frontend-calendar/pull/240.