### PR TITLE
esn-frontend-calendar#371: Added the isAbsoluteURL function to urlUtils

### DIFF
--- a/src/frontend/js/modules/url.js
+++ b/src/frontend/js/modules/url.js
@@ -36,9 +36,18 @@
         return string.match(/(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g) !== null;
       }
 
+      function isAbsoluteURL(url) {
+        if (typeof url !== 'string') {
+          return false;
+        }
+
+        return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url);
+      }
+
       return {
         updateUrlParameter,
-        isValidURL
+        isValidURL,
+        isAbsoluteURL
       };
 
     })

--- a/src/frontend/js/modules/url.spec.js
+++ b/src/frontend/js/modules/url.spec.js
@@ -95,6 +95,24 @@ describe('The esn.url Angular module', function() {
         expect(urlUtils.isValidURL('/123')).to.be.false;
       });
     });
+
+    describe('The isAbsoluteURL function', function() {
+      it('should return true if the url is an absolute URL', function() {
+        expect(urlUtils.isAbsoluteURL('http://123.com')).to.be.true;
+      });
+
+      it('should return false if the url is a relative URL', function() {
+        expect(urlUtils.isAbsoluteURL('123.com')).to.be.false;
+      });
+
+      it('should return false if the url is invalid', function() {
+        expect(urlUtils.isAbsoluteURL('someinvalid/string')).to.be.false;
+      });
+
+      it('should return false if the url is not a string', function() {
+        expect(urlUtils.isAbsoluteURL(123)).to.be.false;
+      });
+    });
   });
 
   describe('The absoluteUrl factory', function() {


### PR DESCRIPTION
Partially resolves https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/371. Please also refer to https://github.com/OpenPaaS-Suite/esn-frontend-calendar/pull/372.