### PR TITLE
esn-frontend-calendar#70: Fixed the app grid not displaying correctly in iOS devices

### DIFF
--- a/src/frontend/css/modules/sidebar.less
+++ b/src/frontend/css/modules/sidebar.less
@@ -27,7 +27,7 @@ body.aside-open {
     bottom: 0;
     left: 0;
 
-    overflow-y: auto;
+    overflow: visible;
   }
 
   #aside-header {
@@ -65,8 +65,11 @@ body.aside-open {
 
   .aside-body {
     padding: 0;
-    padding-bottom: 40px;
-    padding-top: 10px;
+    padding-bottom: 104px;
+    padding-top: 8px;
+    max-height: calc(100vh - 56px);
+    overflow: auto;
+    position: relative;
 
     &.hideHeader {
       padding-top: 0;


### PR DESCRIPTION
Resolves https://github.com/OpenPaaS-Suite/esn-frontend-calendar/issues/70 once and for all.

- Result:

![ios-app-grid-fix](https://user-images.githubusercontent.com/24670327/111123532-0630f500-85a2-11eb-9cb7-1161bf987fd2.png)

- The other applications are not affected:

![ios-app-grid-fix-android](https://user-images.githubusercontent.com/24670327/111123543-0a5d1280-85a2-11eb-9db4-972a8a3eb246.jpg)
