### PR TITLE
#104: Prevent error looping when fallback src not found

### DIFF
--- a/src/frontend/js/modules/core.js
+++ b/src/frontend/js/modules/core.js
@@ -127,7 +127,11 @@ const _ = require('lodash');
       return {
         link: function postLink(scope, element, attrs) {
           element.bind('error', function() {
-            angular.element(this).attr('src', attrs.fallbackSrc);
+            if (angular.element(this).attr('src') !== attrs.fallbackSrc) {
+              angular.element(this).attr('src', attrs.fallbackSrc);
+            } else {
+              console.warn(`Img fallback src ${attrs.fallbackSrc} not found.`);
+            }
           });
         }
       };


### PR DESCRIPTION
Display one console warn instead of looping on trying to fetch fallback src

![image](https://user-images.githubusercontent.com/13099240/122082444-4ea9ba00-ce00-11eb-85ed-a3944a84a3f5.png)
