### PR TITLE
linagora/esn-frontend-common-libs#104: Remove former login css style

### DIFF
--- a/src/frontend/css/modules/login.less
+++ b/src/frontend/css/modules/login.less
@@ -1,22 +1,3 @@
-body.login {
-  background: url('/images/login-360.jpg') no-repeat right center;
-  -webkit-background-size: cover;
-  background-size: cover;
-  &:before {
-    height: 49%;
-    width: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-    background: url('/images/white-logo.svg') no-repeat top left;
-    background-position: top 2% center;
-    background-size: 300px;
-    content: "";
-    z-index: 0;
-    .hidden-xs;
-  }
-}
-
 ul.login-oauth {
   list-style: none;
   padding-left: 0px;


### PR DESCRIPTION
This style was used in former login page provided by the backend.

Removing it remove 404