### PR TITLE
linagora/customers#51 redirect the user to the login url when the session is broken due to idle timeout

### DIFF
--- a/src/frontend/js/modules/session.js
+++ b/src/frontend/js/modules/session.js
@@ -124,7 +124,7 @@
           if (error.code && error.code === 401) {
             $log.error('failed to fetch the current user', error);
 
-            return esnAuth.signout();
+            return esnAuth.signin();
           }
 
           $scope.$apply(() => {

--- a/src/frontend/js/modules/session.spec.js
+++ b/src/frontend/js/modules/session.spec.js
@@ -378,7 +378,7 @@ describe('The esn.session Angular module', function() {
       };
 
       esnAuth = {
-        signout: sinon.spy(),
+        signin: sinon.spy(),
         init: sinon.stub().returns($q.when({}))
       };
 
@@ -405,7 +405,7 @@ describe('The esn.session Angular module', function() {
       return controller;
     }
 
-    it('should signout the user if he is unauthorized ( broken session )', function() {
+    it('should redirect to the signin url if the user is unauthorized ( broken session )', function() {
       esnAuth.init = sinon.stub().returns($q.reject({
         code: 401
       }));
@@ -413,17 +413,17 @@ describe('The esn.session Angular module', function() {
       initController();
       this.$scope.$digest();
 
-      expect(esnAuth.signout).to.have.been.called;
+      expect(esnAuth.signin).to.have.been.called;
     });
 
-    it('shouldn\'t signout the user when a non 401 error was received', function() {
+    it('shouldn\'t redirect to the signin url when a non 401 error was received', function() {
       esnAuth.init = sinon.stub().returns($q.reject({
         code: 500
       }));
 
       initController();
 
-      expect(esnAuth.signout).to.not.have.been.called;
+      expect(esnAuth.signin).to.not.have.been.called;
     });
   });
 });


### PR DESCRIPTION
fixes the double redirection introduced in https://github.com/linagora/esn-frontend-common-libs/pull/230
- redirect 1: logout the user and redirect to the signout page
- redirect 2: the user is bought back to the app page and is detected as not logged in
- redirect 3: the user is redirected to the login page 

in this PR:
- redirection 1: redirect the user to the login page ( since the token is already invalid )
- redirection 2: the user is brought back to the app after authentication