### PR TITLE
linagora/customers#80 redirect to login when the silent renew has failed

### DIFF
--- a/src/frontend/js/modules/auth/auth.service.js
+++ b/src/frontend/js/modules/auth/auth.service.js
@@ -32,6 +32,7 @@ function esnAuth($q, $log, $window, userAPI, httpConfigurer) {
 
     auth.addEventListener('silentRenewError', err => {
       $log.info('esn.auth - Silent renew error', err);
+      auth.signin();
     });
 
     auth.addEventListener('sessionExpired', () => {


### PR DESCRIPTION
related to https://github.com/linagora/customers/issues/80
- most common error: `invalid_grant`
