### PR TITLE
customers#55: Fix basic auth on sign in complete

### DIFF
--- a/src/frontend/js/modules/auth/auth.service.js
+++ b/src/frontend/js/modules/auth/auth.service.js
@@ -9,9 +9,11 @@ function esnAuth($q, $log, $window, userAPI, httpConfigurer) {
   const signInCompleteDeferred = $q.defer();
   const onSignInComplete = data => {
     $log.debug('esn.auth - User signed in');
-    if (data.headers) {
+
+    signInCompleteDeferred.resolve();
+
+    if (data && data.headers) {
       httpConfigurer.setHeaders(data.headers);
-      signInCompleteDeferred.resolve();
     }
   };
 


### PR DESCRIPTION
Allow to complete sign in without header information (in case of Basic Auth)

related to linagora/esn-frontend-common-libs#225